### PR TITLE
move registry and event-queue state into re-frame.core

### DIFF
--- a/src/re_frame/cofx.cljc
+++ b/src/re_frame/cofx.cljc
@@ -2,15 +2,14 @@
   (:require
     [re-frame.db           :refer [app-db]]
     [re-frame.interceptor  :refer [->interceptor]]
-    [re-frame.registrar    :refer [get-handler clear-handlers register-handler]]
+    [re-frame.registry     :as reg]
     [re-frame.loggers      :refer [console]]))
 
 
 ;; -- Registration ------------------------------------------------------------
 
 (def kind :cofx)
-(assert (re-frame.registrar/kinds kind))
-(def register  (partial register-handler kind))
+(assert (re-frame.registry/kinds kind))
 
 
 ;; -- Interceptor -------------------------------------------------------------
@@ -36,33 +35,30 @@
    the current value of `:coeffects` and, optionally, the value. The registered handler
    is expected to return a modified coeffect.
    "
-  ([id]
+  ([registry id]
   (->interceptor
     :id      :coeffects
     :before  (fn coeffects-before
                [context]
-               (update context :coeffects (get-handler kind id)))))
-  ([id value]
+               (update context :coeffects (reg/get-handler registry kind id)))))
+  ([registry id value]
    (->interceptor
      :id     :coeffects
      :before  (fn coeffects-before
                 [context]
-                (update context :coeffects (get-handler kind id) value)))))
+                (update context :coeffects (reg/get-handler registry kind id) value)))))
 
 
 ;; -- Builtin CoEffects Handlers  ---------------------------------------------
 
-;; :db
-;;
-;; Adds to coeffects the value in `app-db`, under the key `:db`
-(register
-  :db
-  (fn db-coeffects-handler
-    [coeffects]
-    (assoc coeffects :db @app-db)))
-
+(defn register-built-in!
+  [registry]
+  (let [register (partial reg/register-handler registry kind)]
+    (register
+     :db
+     (fn db-coeffects-handler
+       [coeffects]
+       (assoc coeffects :db @app-db)))))
 
 ;; Because this interceptor is used so much, we reify it
-(def inject-db (inject-cofx :db))
-
-
+;; (def inject-db (inject-cofx :db))

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -9,6 +9,7 @@
     [re-frame.router           :as router]
     [re-frame.loggers          :as loggers]
     [re-frame.registrar        :as registrar]
+    [re-frame.registry         :as reg]
     [re-frame.interceptor      :as interceptor]
     [re-frame.std-interceptors :as std-interceptors :refer [db-handler->interceptor
                                                              fx-handler->interceptor
@@ -16,9 +17,13 @@
     [clojure.set               :as set]))
 
 
+;; -- state
+(def registry (reg/make-registry))
+(def ev-queue (router/->EventQueue :idle interop/empty-queue {} registry))
+
 ;; --  dispatch
-(def dispatch         router/dispatch)
-(def dispatch-sync    router/dispatch-sync)
+(def dispatch         (partial router/dispatch ev-queue))
+(def dispatch-sync    (partial router/dispatch-sync ev-queue registry))
 
 
 ;; XXX move API functions up to this core level - to enable code completion and docs
@@ -53,26 +58,30 @@
   This is a low level, advanced function.  You should probably be using reg-sub
   instead."
   [query-id handler-fn]
-  (registrar/register-handler subs/kind query-id handler-fn))
+  (reg/register-handler registry subs/kind query-id handler-fn))
 
-(def reg-sub             subs/reg-sub)
-(def subscribe           subs/subscribe)
+(def reg-sub      (partial subs/reg-sub registry))
+(def subscribe    (partial subs/subscribe registry))
 
-(def clear-sub    (partial registrar/clear-handlers subs/kind))
+(def clear-sub    (partial reg/clear-handlers registry subs/kind))
 (def clear-subscription-cache! subs/clear-subscription-cache!)
 
 ;; -- effects
-(def reg-fx      fx/register)
-(def clear-fx    (partial registrar/clear-handlers fx/kind))
+(def reg-fx      (partial reg/register-handler registry fx/kind))
+(def clear-fx    (partial reg/clear-handlers registry fx/kind))
+(def fx-do-fx    (fx/do-fx registry))
+(fx/register-built-in! registry ev-queue)
 
 ;; -- coeffects
-(def reg-cofx    cofx/register)
-(def inject-cofx cofx/inject-cofx)
-(def clear-cofx (partial registrar/clear-handlers cofx/kind))
+(def reg-cofx    (partial reg/register-handler registry cofx/kind))
+(def inject-cofx (partial cofx/inject-cofx registry))
+(def clear-cofx  (partial reg/clear-handlers registry cofx/kind))
+(def cofx-inject-db (cofx/inject-cofx registry :db))
+(cofx/register-built-in! registry)
 
 
 ;; --  Events
-(def clear-event (partial registrar/clear-handlers events/kind))
+(def clear-event (partial reg/clear-handlers registry events/kind))
 
 (defn reg-event-db
   "Register the given `id`, typically a keyword, with the combination of
@@ -86,21 +95,21 @@
   ([id db-handler]
     (reg-event-db id nil db-handler))
   ([id interceptors db-handler]
-   (events/register id [cofx/inject-db fx/do-fx interceptors (db-handler->interceptor db-handler)])))
+   (events/register registry id [cofx-inject-db fx-do-fx interceptors (db-handler->interceptor db-handler)])))
 
 
 (defn reg-event-fx
   ([id fx-handler]
    (reg-event-fx id nil fx-handler))
   ([id interceptors fx-handler]
-   (events/register id [cofx/inject-db fx/do-fx interceptors (fx-handler->interceptor fx-handler)])))
+   (events/register registry id [cofx-inject-db fx-do-fx interceptors (fx-handler->interceptor fx-handler)])))
 
 
 (defn reg-event-ctx
   ([id handler]
    (reg-event-ctx id nil handler))
   ([id interceptors handler]
-   (events/register id [cofx/inject-db fx/do-fx interceptors (ctx-handler->interceptor handler)])))
+   (events/register registry id [cofx-inject-db fx-do-fx interceptors (ctx-handler->interceptor handler)])))
 
 
 ;; --  Logging -----
@@ -168,12 +177,12 @@
   ([f]
    (add-post-event-callback f f))   ;; use f as its own identifier
   ([id f]
-   (router/add-post-event-callback re-frame.router/event-queue id f)))
+   (router/add-post-event-callback ev-queue id f)))
 
 
 (defn remove-post-event-callback
   [id]
-  (router/remove-post-event-callback re-frame.router/event-queue id))
+  (router/remove-post-event-callback ev-queue id))
 
 
 ;; --  Deprecation Messages

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -138,12 +138,12 @@
   Checkpoint includes app-db, all registered handlers and all subscriptions.
   "
   []
-  (let [handlers @registrar/kind->id->handler
+  (let [handlers (-> registry :kind->id->handler deref)
         app-db   @db/app-db
-				subs-cache @subs/query->reaction]
+        subs-cache @subs/query->reaction]
     (fn []
-			;; call `dispose!` on all current subscriptions which
-			;; didn't originally exist.
+      ;; call `dispose!` on all current subscriptions which
+      ;; didn't originally exist.
       (let [original-subs (set (vals subs-cache))
             current-subs  (set (vals @subs/query->reaction))]
         (doseq [sub (set/difference current-subs original-subs)]
@@ -152,7 +152,7 @@
       ;; Reset the atoms
       ;; We don't need to reset subs/query->reaction, as
       ;; disposing of the subs removes them from the cache anyway
-      (reset! registrar/kind->id->handler handlers)
+      (reset! (:kind->id->handler registry) handlers)
       (reset! db/app-db app-db)
       nil)))
 

--- a/src/re_frame/events.cljc
+++ b/src/re_frame/events.cljc
@@ -1,15 +1,14 @@
 (ns re-frame.events
-  (:require [re-frame.db          :refer [app-db]]
-            [re-frame.utils       :refer [first-in-vector]]
+  (:require [re-frame.utils       :refer [first-in-vector]]
             [re-frame.interop     :refer [empty-queue debug-enabled?]]
-            [re-frame.registrar   :refer [get-handler register-handler]]
+            [re-frame.registry    :as reg]
             [re-frame.loggers     :refer [console]]
             [re-frame.interceptor :as  interceptor]
             [re-frame.trace       :as trace :include-macros true]))
 
 
 (def kind :event)
-(assert (re-frame.registrar/kinds kind))
+(assert (re-frame.registry/kinds kind))
 
 (defn- flatten-and-remove-nils
   "`interceptors` might have nested collections, and contain nil elements.
@@ -40,8 +39,8 @@
    before registration.
 
    An `event handler` will likely be at the end of the chain (wrapped in an interceptor)."
-  [id interceptors]
-  (register-handler kind id (flatten-and-remove-nils id interceptors)))
+  [registry id interceptors]
+  (reg/register-handler registry kind id (flatten-and-remove-nils id interceptors)))
 
 
 
@@ -51,9 +50,9 @@
 
 (defn handle
   "Given an event vector, look up the associated intercepter chain, and execute it."
-  [event-v]
+  [registry event-v]
   (let [event-id  (first-in-vector event-v)]
-    (if-let [interceptors  (get-handler kind event-id true)]
+    (if-let [interceptors  (reg/get-handler registry kind event-id true)]
       (if *handling*
         (console :error (str "re-frame: while handling \"" *handling* "\", dispatch-sync was called for \"" event-v "\". You can't call dispatch-sync within an event handler."))
         (binding [*handling*  event-v]

--- a/src/re_frame/fx.cljc
+++ b/src/re_frame/fx.cljc
@@ -5,19 +5,19 @@
     [re-frame.interceptor :refer [->interceptor]]
     [re-frame.interop     :refer [set-timeout!]]
     [re-frame.events      :as events]
-    [re-frame.registrar   :refer [get-handler clear-handlers register-handler]]
+    [re-frame.registry    :as reg]
     [re-frame.loggers     :refer [console]]))
 
 
 ;; -- Registration ------------------------------------------------------------
 
 (def kind :fx)
-(assert (re-frame.registrar/kinds kind))
-(def register  (partial register-handler kind))
+(assert (re-frame.registry/kinds kind))
+;; (def register  (partial register-handler kind))
 
 ;; -- Interceptor -------------------------------------------------------------
 
-(def do-fx
+(defn do-fx
   "An interceptor which actions a `context's` (side) `:effects`.
 
   For each key in the `:effects` map, call the `effects handler` previously
@@ -29,94 +29,99 @@
        :undo      \"set flag\"}
   call the registered effects handlers for each of the map's keys:
   `:dispatch`, `:undo` and `:db`."
+  [registry]
   (->interceptor
     :id :do-fx
     :after (fn do-fx-after
              [context]
              (doseq [[effect-k value] (:effects context)]
-               (if-let [effect-fn (get-handler kind effect-k true)]
+               (if-let [effect-fn (reg/get-handler registry kind effect-k true)]
                  (effect-fn value))))))
 
 ;; -- Builtin Effect Handlers  ------------------------------------------------
 
-;; :dispatch-later
-;;
-;; `dispatch` one or more events after given delays. Expects a collection
-;; of maps with two keys:  :`ms` and `:dispatch`
-;;
-;; usage:
-;;
-;;    {:dispatch-later [{:ms 200 :dispatch [:event-id "param"]}    ;;  in 200ms do this: (dispatch [:event-id "param"])
-;;                      {:ms 100 :dispatch [:also :this :in :100ms]}]}
-;;
-(register
-  :dispatch-later
-  (fn [value]
-    (doseq [{:keys [ms dispatch] :as effect} value]
-        (if (or (empty? dispatch) (not (number? ms)))
-          (console :error "re-frame: ignoring bad :dispatch-later value:" effect)
-          (set-timeout! #(router/dispatch dispatch) ms)))))
+(defn register-built-in!
+  [registry event-queue]
+  (let [register (partial reg/register-handler registry kind)]
+
+    ;; :dispatch-later
+    ;;
+    ;; `dispatch` one or more events after given delays. Expects a collection
+    ;; of maps with two keys:  :`ms` and `:dispatch`
+    ;;
+    ;; usage:
+    ;;
+    ;;    {:dispatch-later [{:ms 200 :dispatch [:event-id "param"]}    ;;  in 200ms do this: (dispatch [:event-id "param"])
+    ;;                      {:ms 100 :dispatch [:also :this :in :100ms]}]}
+    ;;
+    (register
+     :dispatch-later
+     (fn [value]
+       (doseq [{:keys [ms dispatch] :as effect} value]
+         (if (or (empty? dispatch) (not (number? ms)))
+           (console :error "re-frame: ignoring bad :dispatch-later value:" effect)
+           (set-timeout! #(router/dispatch event-queue dispatch) ms)))))
 
 
-;; :dispatch
-;;
-;; `dispatch` one event. Excepts a single vector.
-;;
-;; usage:
-;;   {:dispatch [:event-id "param"] }
-
-(register
-  :dispatch
-  (fn [value]
-    (if-not (vector? value)
-      (console :error "re-frame: ignoring bad :dispatch value. Expected a vector, but got:" value)
-      (router/dispatch value))))
-
-
-;; :dispatch-n
-;;
-;; `dispatch` more than one event. Expects a list or vector of events. Something for which
-;; sequential? returns true.
-;;
-;; usage:
-;;   {:dispatch-n (list [:do :all] [:three :of] [:these])}
-;;
-(register
-  :dispatch-n
-  (fn [value]
-    (if-not (sequential? value)
-      (console :error "re-frame: ignoring bad :dispatch-n value. Expected a collection, got got:" value))
-    (doseq [event value] (router/dispatch event))))
+    ;; :dispatch
+    ;;
+    ;; `dispatch` one event. Excepts a single vector.
+    ;;
+    ;; usage:
+    ;;   {:dispatch [:event-id "param"] }
+    ;;
+    (register
+     :dispatch
+     (fn [value]
+       (if-not (vector? value)
+         (console :error "re-frame: ignoring bad :dispatch value. Expected a vector, but got:" value)
+         (router/dispatch event-queue value))))
 
 
-;; :deregister-event-handler
-;;
-;; removes a previously registered event handler. Expects either a single id (
-;; typically a keyword), or a seq of ids.
-;;
-;; usage:
-;;   {:deregister-event-handler :my-id)}
-;; or:
-;;   {:deregister-event-handler [:one-id :another-id]}
-;;
-(register
-  :deregister-event-handler
-  (fn [value]
-    (let [clear-event (partial clear-handlers events/kind)]
-      (if (sequential? value)
-        (doseq [event (if (sequential? value) value [value])]
-          (clear-event event))))))
+    ;; :dispatch-n
+    ;;
+    ;; `dispatch` more than one event. Expects a list or vector of events. Something for which
+    ;; sequential? returns true.
+    ;;
+    ;; usage:
+    ;;   {:dispatch-n (list [:do :all] [:three :of] [:these])}
+    ;;
+    (register
+     :dispatch-n
+     (fn [value]
+       (if-not (sequential? value)
+         (console :error "re-frame: ignoring bad :dispatch-n value. Expected a collection, got got:" value))
+       (doseq [event value] (router/dispatch event-queue event))))
 
 
-;; :db
-;;
-;; reset! app-db with a new value. Expects a map.
-;;
-;; usage:
-;;   {:db  {:key1 value1 key2 value2}}
-;;
-(register
-  :db
-  (fn [value]
-    (reset! app-db value)))
+    ;; :deregister-event-handler
+    ;;
+    ;; removes a previously registered event handler. Expects either a single id (
+    ;; typically a keyword), or a seq of ids.
+    ;;
+    ;; usage:
+    ;;   {:deregister-event-handler :my-id)}
+    ;; or:
+    ;;   {:deregister-event-handler [:one-id :another-id]}
+    ;;
+    (register
+     :deregister-event-handler
+     (fn [value]
+       (let [clear-event (partial reg/clear-handlers registry events/kind)]
+         (if (sequential? value)
+           (doseq [event (if (sequential? value) value [value])]
+             (clear-event event))))))
+
+
+    ;; :db
+    ;;
+    ;; reset! app-db with a new value. Expects a map.
+    ;;
+    ;; usage:
+    ;;   {:db  {:key1 value1 key2 value2}}
+    ;;
+    (register
+     :db
+     (fn [value]
+       (reset! app-db value)))))
 

--- a/src/re_frame/registry.cljc
+++ b/src/re_frame/registry.cljc
@@ -1,0 +1,61 @@
+(ns re-frame.registry
+  "In many places, re-frame asks you to associate an `id` (keyword)
+  with a `handler` (function).  This namespace contains the
+  central registry of such associations."
+  (:require  [re-frame.interop :refer [debug-enabled?]]
+             [re-frame.loggers :refer [console]]))
+
+
+;; kinds of handlers
+(def kinds #{:event :fx :cofx :sub})
+
+(defprotocol IRegistry
+  (get-handler
+    [this kind]
+    [this kind id]
+    [this kind id required?])
+
+  (register-handler
+    [this kind id handler-fn])
+
+  (clear-handlers
+    [this]
+    [this kind]
+    [this kind id]))
+
+(defrecord Registry [kinds kind->id->handler]
+  IRegistry
+  (get-handler [this kind]
+    (get @kind->id->handler kind))
+  (get-handler [this kind id]
+    (get-in @kind->id->handler [kind id]))
+  (get-handler [this kind id required?]
+    (let [handler (get-handler this kind id)]
+      (when debug-enabled?                                   ;; This is in a separate when so Closure DCE can run
+        (when (and required? (nil? handler))                 ;; Otherwise you'd need to type hint the and with a ^boolean for DCE.
+          (console :error "re-frame: no " (str kind) " handler registered for:" id)))
+      handler))
+
+  (register-handler [this kind id handler-fn]
+    (when debug-enabled?                                       ;; This is in a separate when so Closure DCE can run
+      (when (get-handler this kind id false)
+        (console :warn "re-frame: overwriting" (str kind) "handler for:" id)))   ;; allow it, but warn. Happens on figwheel reloads.
+    (swap! kind->id->handler assoc-in [kind id] handler-fn)
+    handler-fn)    ;; note: returns the just registered handler
+
+  (clear-handlers [this] ;; clear all kinds
+    (reset! kind->id->handler {}))
+  (clear-handlers [this kind] ;; clear all handlers for this kind
+    (assert (kinds kind))
+    (swap! kind->id->handler dissoc kind))
+  (clear-handlers [this kind id] ;; clear a single handler for a kind
+    (assert (kinds kind))
+    (if (get-handler this kind id)
+      (swap! kind->id->handler update-in [kind] dissoc id)
+      (console :warn "re-frame: can't clear" (str kind) "handler for" (str id ". Handler not found.")))))
+
+(defn make-registry []
+  ;; This atom contains a register of all handlers.
+  ;; Contains a map keyed first by `kind` (of handler), and then `id`.
+  ;; Leaf nodes are handlers.
+  (->Registry kinds (atom {})))

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -3,7 +3,6 @@
   (:require
     [re-frame.interceptor :refer [->interceptor get-effect get-coeffect assoc-coeffect assoc-effect]]
     [re-frame.loggers :refer [console]]
-    [re-frame.registrar :as registrar]
     [re-frame.db :refer [app-db]]
     [clojure.data :as data]
     [re-frame.cofx :as cofx]

--- a/test/re-frame/restore_test.cljs
+++ b/test/re-frame/restore_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame.restore-test
   (:require [cljs.test :refer-macros [is deftest async use-fixtures testing]]
-            [re-frame.core :refer [make-restore-fn reg-sub subscribe]]
+            [re-frame.core :as core :refer [make-restore-fn reg-sub subscribe]]
             [re-frame.subs :as subs]))
 
 ;; TODO: future tests in this area could check DB state and registrations are being correctly restored.
 
-(use-fixtures :each {:before subs/clear-all-handlers!})
+(use-fixtures :each {:before (partial subs/clear-all-handlers! core/registry)})
 
 (defn one? [x] (= 1 x))
 (defn two? [x] (= 2 x))

--- a/test/re-frame/subs_test.cljs
+++ b/test/re-frame/subs_test.cljs
@@ -1,128 +1,147 @@
 (ns re-frame.subs-test
   (:require [cljs.test         :as test :refer-macros [is deftest testing]]
             [reagent.ratom     :as r :refer-macros [reaction]]
+            [re-frame.registry :as reg]
             [re-frame.subs     :as subs]
             [re-frame.db       :as db]
             [re-frame.core     :as re-frame]))
 
-(test/use-fixtures :each {:before (fn [] (subs/clear-all-handlers!))})
+(def registry (atom nil))
 
-;=====test basic subscriptions  ======
+(defn reg-sub-raw
+  "Associate a given `query id` with a given subscription handler function `handler-fn`
+   which is expected to take two arguments: app-db and query vector, and return
+   a `reaction`.
+
+  This is a low level, advanced function.  You should probably be using reg-sub
+  instead."
+  [query-id handler-fn]
+  (reg/register-handler @registry subs/kind query-id handler-fn))
+
+
+(test/use-fixtures :each {:before (fn []
+                                    (reset! registry (reg/make-registry))
+                                    (subs/clear-all-handlers! @registry))})
+
+;;=====test basic subscriptions  ======
 
 (deftest test-reg-sub
-  (re-frame/reg-sub-raw
-    :test-sub
-    (fn [db [_]] (reaction (deref db))))
+  (reg-sub-raw
+   :test-sub
+   (fn [db [_]] (reaction (deref db))))
 
-  (let [test-sub (subs/subscribe [:test-sub])]
+  (let [test-sub (subs/subscribe @registry [:test-sub])]
     (is (= @db/app-db @test-sub))
     (reset! db/app-db 1)
     (is (= 1 @test-sub))))
 
 (deftest test-chained-subs
-  (re-frame/reg-sub-raw
-    :a-sub
-    (fn [db [_]] (reaction (:a @db))))
+  (reg-sub-raw
+   :a-sub
+   (fn [db [_]] (reaction (:a @db))))
 
-  (re-frame/reg-sub-raw
-    :b-sub
-    (fn [db [_]] (reaction (:b @db))))
+  (reg-sub-raw
+   :b-sub
+   (fn [db [_]] (reaction (:b @db))))
 
-  (re-frame/reg-sub-raw
-    :a-b-sub
-    (fn [db [_]]
-      (let [a (subs/subscribe [:a-sub])
-            b (subs/subscribe [:b-sub])]
-        (reaction {:a @a :b @b}))))
+  (reg-sub-raw
+   :a-b-sub
+   (fn [db [_]]
+     (let [a (subs/subscribe @registry [:a-sub])
+           b (subs/subscribe @registry [:b-sub])]
+       (reaction {:a @a :b @b}))))
 
-  (let [test-sub (subs/subscribe [:a-b-sub])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1 :b 2} @test-sub))
     (swap! db/app-db assoc :b 3)
     (is (= {:a 1 :b 3} @test-sub))))
 
 (deftest test-sub-parameters
-  (re-frame/reg-sub-raw
-    :test-sub
-    (fn [db [_ b]] (reaction [(:a @db) b])))
+  (reg-sub-raw
+   :test-sub
+   (fn [db [_ b]] (reaction [(:a @db) b])))
 
-  (let [test-sub (subs/subscribe [:test-sub :c])]
+  (let [test-sub (subs/subscribe @registry [:test-sub :c])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= [1 :c] @test-sub))))
 
 
 (deftest test-sub-chained-parameters
-  (re-frame/reg-sub-raw
-    :a-sub
-    (fn [db [_ a]] (reaction [(:a @db) a])))
+  (reg-sub-raw
+   :a-sub
+   (fn [db [_ a]] (reaction [(:a @db) a])))
 
-  (re-frame/reg-sub-raw
-    :b-sub
-    (fn [db [_ b]] (reaction [(:b @db) b])))
+  (reg-sub-raw
+   :b-sub
+   (fn [db [_ b]] (reaction [(:b @db) b])))
 
-  (re-frame/reg-sub-raw
-    :a-b-sub
-    (fn [db [_ c]]
-      (let [a (subs/subscribe [:a-sub c])
-            b (subs/subscribe [:b-sub c])]
-        (reaction {:a @a :b @b}))))
+  (reg-sub-raw
+   :a-b-sub
+   (fn [db [_ c]]
+     (let [a (subs/subscribe @registry [:a-sub c])
+           b (subs/subscribe @registry [:b-sub c])]
+       (reaction {:a @a :b @b}))))
 
-  (let [test-sub (subs/subscribe [:a-b-sub :c])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub :c])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a [1 :c], :b [2 :c]} @test-sub))))
 
 (deftest test-nonexistent-sub
-  (is (nil? (re-frame/subscribe [:non-existence]))))
+  (is (nil? (subs/subscribe @registry [:non-existence]))))
 
-;============== test cached-subs ================
+;;============== test cached-subs ================
 (def side-effect-atom (atom 0))
 
 (deftest test-cached-subscriptions
   (reset! side-effect-atom 0)
 
-  (re-frame/reg-sub-raw
-    :side-effecting-handler
-    (fn side-effect
-      [db [_] [_]]
-      (swap! side-effect-atom inc)
-      (reaction @db)))
+  (reg-sub-raw
+   :side-effecting-handler
+   (fn side-effect
+     [db [_] [_]]
+     (swap! side-effect-atom inc)
+     (reaction @db)))
 
- (let [test-sub (subs/subscribe [:side-effecting-handler])]
+  (let [test-sub (subs/subscribe @registry [:side-effecting-handler])]
     (reset! db/app-db :test)
     (is (= :test @test-sub))
     (is (= @side-effect-atom 1))
-    (subs/subscribe [:side-effecting-handler])  ;; this should be handled by cache
+    (subs/subscribe @registry [:side-effecting-handler])  ;; this should be handled by cache
     (is (= @side-effect-atom 1))
-    (subs/subscribe [:side-effecting-handler :a]) ;; should fire again because of the param
+    (subs/subscribe @registry [:side-effecting-handler :a]) ;; should fire again because of the param
     (is (= @side-effect-atom 2))
-    (subs/subscribe [:side-effecting-handler :a]) ;; this should be handled by cache
+    (subs/subscribe @registry [:side-effecting-handler :a]) ;; this should be handled by cache
     (is (= @side-effect-atom 2))))
 
-;============== test register-pure macros ================
+;;============== test register-pure macros ================
 
 (deftest test-reg-sub-macro
   (subs/reg-sub
-    :test-sub
-    (fn [db [_]] db))
+   @registry
+   :test-sub
+   (fn [db [_]] db))
 
-  (let [test-sub (subs/subscribe [:test-sub])]
+  (let [test-sub (subs/subscribe @registry [:test-sub])]
     (is (= @db/app-db @test-sub))
     (reset! db/app-db 1)
     (is (= 1 @test-sub))))
 
 (deftest test-reg-sub-macro-singleton
   (subs/reg-sub
-    :a-sub
-    (fn [db [_]] (:a db)))
+   @registry
+   :a-sub
+   (fn [db [_]] (:a db)))
 
   (subs/reg-sub
-    :a-b-sub
-    (fn [_ _ _]
-      (subs/subscribe [:a-sub]))
-    (fn [a [_]]
-      {:a a}))
+   @registry
+   :a-b-sub
+   (fn [_ _ _]
+     (subs/subscribe @registry [:a-sub]))
+   (fn [a [_]]
+     {:a a}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1} @test-sub))
     (swap! db/app-db assoc :b 3)
@@ -130,22 +149,25 @@
 
 (deftest test-reg-sub-macro-vector
   (subs/reg-sub
-    :a-sub
-    (fn [db [_]] (:a db)))
+   @registry
+   :a-sub
+   (fn [db [_]] (:a db)))
 
   (subs/reg-sub
-    :b-sub
-    (fn [db [_]] (:b db)))
+   @registry
+   :b-sub
+   (fn [db [_]] (:b db)))
 
   (subs/reg-sub
-    :a-b-sub
-    (fn [_ _ _]
-      [(subs/subscribe [:a-sub])
-       (subs/subscribe [:b-sub])])
-    (fn [[a b] [_]]
-      {:a a :b b}))
+   @registry
+   :a-b-sub
+   (fn [_ _ _]
+     [(subs/subscribe @registry [:a-sub])
+      (subs/subscribe @registry [:b-sub])])
+   (fn [[a b] [_]]
+     {:a a :b b}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1 :b 2} @test-sub))
     (swap! db/app-db assoc :b 3)
@@ -153,22 +175,25 @@
 
 (deftest test-reg-sub-macro-map
   (subs/reg-sub
-    :a-sub
-    (fn [db [_]] (:a db)))
+   @registry
+   :a-sub
+   (fn [db [_]] (:a db)))
 
   (subs/reg-sub
-    :b-sub
-    (fn [db [_]] (:b db)))
+   @registry
+   :b-sub
+   (fn [db [_]] (:b db)))
 
   (subs/reg-sub
-    :a-b-sub
-    (fn [_ _ _]
-      {:a (subs/subscribe [:a-sub])
-       :b (subs/subscribe [:b-sub])})
-    (fn [{:keys [a b]} [_]]
-      {:a a :b b}))
+   @registry
+   :a-b-sub
+   (fn [_ _ _]
+     {:a (subs/subscribe @registry [:a-sub])
+      :b (subs/subscribe @registry [:b-sub])})
+   (fn [{:keys [a b]} [_]]
+     {:a a :b b}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1 :b 2} @test-sub))
     (swap! db/app-db assoc :b 3)
@@ -176,65 +201,74 @@
 
 (deftest test-sub-macro-parameters
   (subs/reg-sub
-    :test-sub
-    (fn [db [_ b]] [(:a db) b]))
+   @registry
+   :test-sub
+   (fn [db [_ b]] [(:a db) b]))
 
-  (let [test-sub (subs/subscribe [:test-sub :c])]
+  (let [test-sub (subs/subscribe @registry [:test-sub :c])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= [1 :c] @test-sub))))
 
 (deftest test-sub-macros-chained-parameters
   (subs/reg-sub
-    :a-sub
-    (fn [db [_ a]] [(:a db) a]))
+   @registry
+   :a-sub
+   (fn [db [_ a]] [(:a db) a]))
 
   (subs/reg-sub
-    :b-sub
-    (fn [db [_ b]] [(:b db) b]))
+   @registry
+   :b-sub
+   (fn [db [_ b]] [(:b db) b]))
 
   (subs/reg-sub
-    :a-b-sub
-    (fn [[_ c] _]
-      [(subs/subscribe [:a-sub c])
-       (subs/subscribe [:b-sub c])])
-    (fn [[a b] [_ c]] {:a a :b b}))
+   @registry
+   :a-b-sub
+   (fn [[_ c] _]
+     [(subs/subscribe @registry [:a-sub c])
+      (subs/subscribe @registry [:b-sub c])])
+   (fn [[a b] [_ c]] {:a a :b b}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub :c])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub :c])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a [1 :c] :b [2 :c]} @test-sub))))
 
 (deftest test-sub-macros-<-
   "test the syntactial sugar"
   (subs/reg-sub
-    :a-sub
-    (fn [db [_]] (:a db)))
+   @registry
+   :a-sub
+   (fn [db [_]] (:a db)))
 
   (subs/reg-sub
-        :a-b-sub
-        :<- [:a-sub]
-        (fn [a [_]] {:a a}))
+   @registry
+   :a-b-sub
+   :<- [:a-sub]
+   (fn [a [_]] {:a a}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1} @test-sub))))
 
 (deftest test-sub-macros-chained-parameters-<-
   "test the syntactial sugar"
   (subs/reg-sub
-    :a-sub
-    (fn [db [_]] (:a db)))
+   @registry
+   :a-sub
+   (fn [db [_]] (:a db)))
 
   (subs/reg-sub
-    :b-sub
-    (fn [db [_]] (:b db)))
+   @registry
+   :b-sub
+   (fn [db [_]] (:b db)))
 
   (subs/reg-sub
-        :a-b-sub
-        :<- [:a-sub]
-        :<- [:b-sub]
-        (fn [[a b] [_ c]] {:a a :b b}))
+   @registry
+   :a-b-sub
+   :<- [:a-sub]
+   :<- [:b-sub]
+   (fn [[a b] [_ c]] {:a a :b b}))
 
-  (let [test-sub (subs/subscribe [:a-b-sub :c])]
+  (let [test-sub (subs/subscribe @registry [:a-b-sub :c])]
     (reset! db/app-db {:a 1 :b 2})
     (is (= {:a 1 :b 2} @test-sub) )))
 
@@ -242,30 +276,35 @@
   (let [sub-called? (atom false)]
     (with-redefs [subs/subscribe (fn [& args] (reset! sub-called? true))]
       (subs/reg-sub
-        :a-sub
-        (fn [db [_]] (:a db)))
+       @registry
+       :a-sub
+       (fn [db [_]] (:a db)))
 
       (subs/reg-sub
-        :b-sub
-        (fn [db [_]] (:b db)))
+       @registry
+       :b-sub
+       (fn [db [_]] (:b db)))
 
       (subs/reg-sub
-        :fn-sub
-        (fn [[_ c] _]
-          [(subs/subscribe [:a-sub c])
-           (subs/subscribe [:b-sub c])])
-        (fn [db [_]] (:b db)))
+       @registry
+       :fn-sub
+       (fn [[_ c] _]
+         [(subs/subscribe @registry [:a-sub c])
+          (subs/subscribe @registry [:b-sub c])])
+       (fn [db [_]] (:b db)))
 
       (subs/reg-sub
-        :a-sugar-sub
-        :<- [:a-sub]
-        (fn [[a] [_ c]] {:a a}))
+       @registry
+       :a-sugar-sub
+       :<- [:a-sub]
+       (fn [[a] [_ c]] {:a a}))
 
       (subs/reg-sub
-        :a-b-sub
-        :<- [:a-sub]
-        :<- [:b-sub]
-        (fn [[a b] [_ c]] {:a a :b b})))
+       @registry
+       :a-b-sub
+       :<- [:a-sub]
+       :<- [:b-sub]
+       (fn [[a b] [_ c]] {:a a :b b})))
 
     (is (false? @sub-called?))))
 
@@ -273,13 +312,14 @@
 
 (deftest test-dynamic-subscriptions
   (subs/reg-sub
+    @registry
     :dyn-sub
     (fn [db ev dynv]
       (first dynv)))
 
   (testing "happy case"
-    (is (= 1 @(subs/subscribe [:dyn-sub] [(r/atom 1)]))))
+    (is (= 1 @(subs/subscribe @registry [:dyn-sub] [(r/atom 1)]))))
   (testing "subscription that doesn't exist"
-    (is (nil? (subs/subscribe [:non-existent] [(r/atom 1)]))))
+    (is (nil? (subs/subscribe @registry [:non-existent] [(r/atom 1)]))))
   (testing "Passing a non-reactive value to a dynamic subscription"
-    (is (thrown-with-msg? js/Error #"No protocol method IDeref" @(subs/subscribe [:dyn-sub] [1])))))
+    (is (thrown-with-msg? js/Error #"No protocol method IDeref" @(subs/subscribe @registry [:dyn-sub] [1])))))


### PR DESCRIPTION
This is part of an attempt to consolidate state into `re-frame.core` so that other re-frame namespaces can be used in a more library-like manner. The goal is not to make this easy to use for regular re-frame users or even the default but rather step by step reduce how state is spread out across the codebase. Later on this should simplify the implementation of "multiple re-frame instances" and similar scenarios (e.g. devcards or using re-frame's eventloop/fx/cofx stuff with non-reagent projects).

There are a few critical pieces of state as far as I can see:
-  **`re-frame.registrar/registry`** for `cofx` `event` `fx` and `sub` 
-  **`re-frame.router/event-queue`** FSM for processing events
-  **`re-frame.db/app-db`** (not addressed in this PR but followup #2)
-  **`re-frame.subs/query->reaction`** (not addressed in this PR but followup #2)

The change done here moves the state from the `re-frame.registry` and `re-frame.router` namespaces into `re-frame.core` and parameterizes the public API accordingly. `re-frame.db/app-db` and `re-frame.subs/query->reaction` are still used directly as before. (This change is more an exploration of the general approach so skipped that bit for now.)

Tests are passing but I'm not sure if the test suite is particularly expansive in the aspects affected by this change.


#### Other Notes

- I made a protocolized version of the registry because it seemed appropriate, it's not really important to the overall change though
- Created a new `re-frame.registry` namespace to replace `re-frame.registrar` (mostly to have the old ns around for comparison)
- A potential continuation of this could be a custom type `ReFrame` or similar that is a composite of the individual pieces of state but there's probably not a lot of immediate benefit to such change.
